### PR TITLE
Change parameter name for commits

### DIFF
--- a/spec/PlatformShFacadeSpec.php
+++ b/spec/PlatformShFacadeSpec.php
@@ -67,7 +67,7 @@ class PlatformShFacadeSpec extends ObjectBehavior
     {
         $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
-        $activity->offsetGet('parameters')->willReturn(['github-pr-head' => 'sha']);
+        $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(true);
         $environment->offsetGet('status')->willReturn('active');
         $environment->getActivities(10)->willReturn([$activity]);
@@ -84,7 +84,7 @@ class PlatformShFacadeSpec extends ObjectBehavior
     {
         $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
-        $activity->offsetGet('parameters')->willReturn(['github-pr-head' => 'sha']);
+        $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(false);
         $activity->wait()->willReturn();
         $environment->offsetGet('status')->willReturn('dirty');

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -37,8 +37,8 @@ class PlatformShFacade
         $waitActivity = null;
         foreach ($activities as $activity) {
             if ($activity['type'] == 'environment.push' &&
-                isset($activity['parameters']['github-pr-head']) &&
-                $activity['parameters']['github-pr-head'] == $sha) {
+                isset($activity['parameters']['new_commit']) &&
+                $activity['parameters']['new_commit'] == $sha) {
                 $waitActivity = $activity;
                 break;
             }


### PR DESCRIPTION
It seems as if Platform.sh has changed the name from github-pr-head to 
new_commit.