### PR TITLE
Add support for replacing route urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,12 @@ variables on CircleCI.
 
 Add the phar file to the commands run on CircleCI and give it the
 configuration file of the test framework as argument. The file should
-have a %site-url% placeholder that will be replaced with the URL of
+have a `%site-url%` placeholder that will be replaced with the URL of
 the Platform.sh environment, with any trailing slashes stripped.
+
+If your Platform.sh project uses [Routes](https://docs.platform.sh/configuration/routes.html) 
+you can refer to route URLs using the pattern `%site-url:[route-index]%`.
+`%site-url:1%` is the URL to the first route etc. 
 
 Working `.circleci/config.yml`:
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ have a `%site-url%` placeholder that will be replaced with the URL of
 the Platform.sh environment, with any trailing slashes stripped.
 
 If your Platform.sh project uses [Routes](https://docs.platform.sh/configuration/routes.html) 
-you can refer to route URLs using the pattern `%site-url:[route-index]%`.
-`%site-url:1%` is the URL to the first route etc. 
+you can refer to route URLs using the pattern `%route-url:[route-index]%`.
+`%route-url:1%` is the URL to the first route etc. 
 
 Working `.circleci/config.yml`:
 

--- a/spec/PlatformShFacadeSpec.php
+++ b/spec/PlatformShFacadeSpec.php
@@ -72,12 +72,31 @@ class PlatformShFacadeSpec extends ObjectBehavior
         $environment->offsetGet('status')->willReturn('active');
         $environment->getActivities(10)->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
         $project->getEnvironment('env')->willReturn($environment);
         $client->getProject('project_id')->willReturn($project);
 
         $this->beConstructedWith($client);
 
-        $this->waitFor('project_id', 'env', 'sha')->shouldReturn('the-url');
+        $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url']);
+    }
+
+    function it_returns_route_urls(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
+    {
+        $activity->offsetGet('type')->willReturn('environment.push');
+        $activity->offsetExists('parameters')->willReturn(true);
+        $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
+        $activity->isComplete()->willReturn(true);
+        $environment->offsetGet('status')->willReturn('active');
+        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn(['route-url-1', 'route-url-2']);
+        $project->getEnvironment('env')->willReturn($environment);
+        $client->getProject('project_id')->willReturn($project);
+
+        $this->beConstructedWith($client);
+
+        $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url', 'route-url-1', 'route-url-2']);
     }
 
     function it_waits_on_incomplete_activity(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
@@ -90,11 +109,12 @@ class PlatformShFacadeSpec extends ObjectBehavior
         $environment->offsetGet('status')->willReturn('dirty');
         $environment->getActivities(10)->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
         $project->getEnvironment('env')->willReturn($environment);
         $client->getProject('project_id')->willReturn($project);
 
         $this->beConstructedWith($client);
 
-        $this->waitFor('project_id', 'env', 'sha')->shouldReturn('the-url');
+        $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url']);
     }
 }

--- a/spec/WaitCommandSpec.php
+++ b/spec/WaitCommandSpec.php
@@ -6,6 +6,7 @@ use Dais\Env;
 use Dais\PlatformShFacade;
 use Dais\WaitCommand;
 use PhpSpec\ObjectBehavior;
+use Platformsh\Client\Model\Environment;
 use Prophecy\Argument;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -16,18 +17,20 @@ class WaitCommandSpec extends ObjectBehavior
         $this->shouldHaveType(WaitCommand::class);
     }
 
-    function it_waits_properly(Env $env, PlatformShFacade $facade, SymfonyStyle $io)
+    function it_waits_properly(Env $env, PlatformShFacade $facade, Environment $environment, SymfonyStyle $io)
     {
         $env->get('DAIS_PLATFORMSH_ID', Argument::any())->willReturn('env');
         $env->get('CIRCLE_SHA1', Argument::any())->willReturn('sha');
         $env->get('CI_PULL_REQUEST', Argument::any())->willReturn('pull/25');
-        $facade->waitFor('env', 'pr-25', 'sha')->willReturn('url')->shouldBeCalled();
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
+        $facade->waitFor('env', 'pr-25', 'sha')->willReturn($environment)->shouldBeCalled();
 
         // No return value to test.
         $this->wait([], $env, $facade, $io);
     }
 
-    function it_replaces_file_placeholders(Env $env, PlatformShFacade $facade, SymfonyStyle $io) {
+    function it_replaces_file_placeholders(Env $env, PlatformShFacade $facade, Environment $environment, SymfonyStyle $io) {
         $file1 = tempnam(sys_get_temp_dir(), 'dais-test-');
         file_put_contents($file1, 'lala %site-url% lolo');
         $file2 = tempnam(sys_get_temp_dir(), 'dais-test-');
@@ -36,7 +39,9 @@ class WaitCommandSpec extends ObjectBehavior
         $env->get('DAIS_PLATFORMSH_ID', Argument::any())->willReturn('env');
         $env->get('CIRCLE_SHA1', Argument::any())->willReturn('sha');
         $env->get('CI_PULL_REQUEST', Argument::any())->willReturn('pull/25');
-        $facade->waitFor('env', 'pr-25', 'sha')->willReturn('the-url')->shouldBeCalled();
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
+        $facade->waitFor('env', 'pr-25', 'sha')->willReturn(['the-url'])->shouldBeCalled();
 
         $this->wait([$file1, $file2], $env, $facade, $io);
 
@@ -44,7 +49,29 @@ class WaitCommandSpec extends ObjectBehavior
         expect(file_get_contents($file2))->toBe('banana the-url ananas');
     }
 
-    function it_prints_an_error_on_non_existent_files(Env $env, PlatformShFacade $facade, SymfonyStyle $io) {
+    function it_replaces_file_route_placeholders(Env $env, PlatformShFacade $facade, Environment $environment, SymfonyStyle $io) {
+        $file1 = tempnam(sys_get_temp_dir(), 'dais-test-');
+        file_put_contents($file1, 'lala %site-url% lolo %site-url:1%');
+        $file2 = tempnam(sys_get_temp_dir(), 'dais-test-');
+        file_put_contents($file2, 'banana %site-url% ananas %site-url:2%');
+
+        $env->get('DAIS_PLATFORMSH_ID', Argument::any())->willReturn('env');
+        $env->get('CIRCLE_SHA1', Argument::any())->willReturn('sha');
+        $env->get('CI_PULL_REQUEST', Argument::any())->willReturn('pull/25');
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([
+          'route-url-1',
+          'route-url-2',
+        ]);
+        $facade->waitFor('env', 'pr-25', 'sha')->willReturn(['the-url', 'route-url-1', 'route-url-2'])->shouldBeCalled();
+
+        $this->wait([$file1, $file2], $env, $facade, $io);
+
+        expect(file_get_contents($file1))->toBe('lala the-url lolo route-url-1');
+        expect(file_get_contents($file2))->toBe('banana the-url ananas route-url-2');
+    }
+
+    function it_prints_an_error_on_non_existent_files(Env $env, PlatformShFacade $facade, Environment $environment, SymfonyStyle $io) {
         $file1 = sys_get_temp_dir() . '/dais-this-file-should-not-exist';
         // Do check that's the case.
         expect(file_exists($file1))->toBe(false);
@@ -53,7 +80,9 @@ class WaitCommandSpec extends ObjectBehavior
         $env->get('DAIS_PLATFORMSH_ID', Argument::any())->willReturn('env');
         $env->get('CIRCLE_SHA1', Argument::any())->willReturn('sha');
         $env->get('CI_PULL_REQUEST', Argument::any())->willReturn('pull/25');
-        $facade->waitFor('env', 'pr-25', 'sha')->willReturn('the-url')->shouldBeCalled();
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
+        $facade->waitFor('env', 'pr-25', 'sha')->willReturn(['the-url'])->shouldBeCalled();
         $io->error($file1 . ' does not exist.')->shouldBeCalled();
 
         $this->wait([$file1], $env, $facade, $io);

--- a/spec/WaitCommandSpec.php
+++ b/spec/WaitCommandSpec.php
@@ -51,9 +51,9 @@ class WaitCommandSpec extends ObjectBehavior
 
     function it_replaces_file_route_placeholders(Env $env, PlatformShFacade $facade, Environment $environment, SymfonyStyle $io) {
         $file1 = tempnam(sys_get_temp_dir(), 'dais-test-');
-        file_put_contents($file1, 'lala %site-url% lolo %site-url:1%');
+        file_put_contents($file1, 'lala %site-url% lolo %route-url:1%');
         $file2 = tempnam(sys_get_temp_dir(), 'dais-test-');
-        file_put_contents($file2, 'banana %site-url% ananas %site-url:2%');
+        file_put_contents($file2, 'banana %site-url% ananas %route-url:2%');
 
         $env->get('DAIS_PLATFORMSH_ID', Argument::any())->willReturn('env');
         $env->get('CIRCLE_SHA1', Argument::any())->willReturn('sha');

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -24,6 +24,12 @@ class PlatformShFacade
         $this->client = $client;
     }
 
+    /**
+     * Wait for environment to be ready and return a list of urls for the environment.
+     *
+     * The first entry is the public url for the environment.
+     * Any following entries are urls to routes for the environment.
+     */
     public function waitFor($projectId, $environmentName, $sha)
     {
         $environment = $this->getEnvironment($this->getProject($projectId), $environmentName);
@@ -52,7 +58,11 @@ class PlatformShFacade
             $waitActivity->wait();
         }
 
-        return $environment->getPublicUrl();
+        return array_merge(
+            [$environment->getPublicUrl()],
+            $environment->getRouteUrls()
+        );
+
     }
 
     /**

--- a/src/WaitCommand.php
+++ b/src/WaitCommand.php
@@ -44,7 +44,7 @@ class WaitCommand
         $urls = $facade->waitFor($platformId, 'pr-' . $prNum, $sha);
         $placeholder_urls = [];
         foreach ($urls as $index => $url) {
-            $placeholder = ($index === 0) ? "%site-url%" : "%site-url:$index%";
+            $placeholder = ($index === 0) ? "%site-url%" : "%route-url:$index%";
             $placeholder_urls[$placeholder] = $url;
         }
 

--- a/src/WaitCommand.php
+++ b/src/WaitCommand.php
@@ -45,25 +45,24 @@ class WaitCommand
         $placeholder_urls = [];
         foreach ($urls as $index => $url) {
             $placeholder = ($index === 0) ? "%site-url%" : "%route-url:$index%";
-            $placeholder_urls[$placeholder] = $url;
+            $placeholder_urls[$placeholder] = rtrim($url, '/');
         }
 
-        foreach ($placeholder_urls as $placeholder => $url) {
-            $url = rtrim($url, '/');
-            foreach ($files as $file) {
-                try {
-                    $this->fileReplace($file, $placeholder, $url, $io);
-                } catch (\RuntimeException $e) {
-                    $io->error($e->getMessage());
-                }
+        foreach ($files as $file) {
+            try {
+                $this->fileReplace($file, $placeholder_urls);
+            } catch (\RuntimeException $e) {
+                $io->error($e->getMessage());
             }
         }
     }
 
     /**
-     * Replace placeholder in file.
+     * Replace placeholders in file.
+     *
+     * Placeholders must be an map of placeholder strings and their corresponding values.
      */
-    protected function fileReplace($file, $placeholder, $url)
+    protected function fileReplace($file, array $placeholder_map)
     {
         if (!file_exists($file)) {
             throw new \RuntimeException($file . " does not exist.");
@@ -74,7 +73,7 @@ class WaitCommand
             throw new \RuntimeException("Could not read " . $file . ".");
         }
 
-        $content = preg_replace("/$placeholder/", $url, $content);
+        $content = str_replace(array_keys($placeholder_map), $placeholder_map, $content);
         if (file_put_contents($file, $content) === false) {
             throw new \RuntimeException("Error writing " . $file . ".");
         }


### PR DESCRIPTION
Platform.sh supports routes which define how HTTP requests are handled.
They can be used to expose multiple apps contained within the same
project using different subdomains. In these situations the single
public url for an environment does not make sens. The method is
deprecated as well.

Here we add support for replacing placeholders for each of these routes.
We use the pattern `%site-url:[route index]%` because routes does not
seem to have any other meaningful identifier. `%site-url:1%` is the first
route etc.

Keep `%site-url%` around for backwards compatability.

Update and expand tests and documentation accordingly.