### PR TITLE
Make route url ordering predictable through alphabetical sorting

### DIFF
--- a/spec/PlatformShFacadeSpec.php
+++ b/spec/PlatformShFacadeSpec.php
@@ -99,6 +99,24 @@ class PlatformShFacadeSpec extends ObjectBehavior
         $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url', 'route-url-1', 'route-url-2']);
     }
 
+    function it_returns_route_urls_in_alphabetical_order(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
+    {
+        $activity->offsetGet('type')->willReturn('environment.push');
+        $activity->offsetExists('parameters')->willReturn(true);
+        $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
+        $activity->isComplete()->willReturn(true);
+        $environment->offsetGet('status')->willReturn('active');
+        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn(['www.the-url', 'api.the-url']);
+        $project->getEnvironment('env')->willReturn($environment);
+        $client->getProject('project_id')->willReturn($project);
+
+        $this->beConstructedWith($client);
+
+        $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url', 'api.the-url', 'www.the-url']);
+    }
+
     function it_waits_on_incomplete_activity(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
         $activity->offsetGet('type')->willReturn('environment.push');

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -28,7 +28,7 @@ class PlatformShFacade
      * Wait for environment to be ready and return a list of urls for the environment.
      *
      * The first entry is the public url for the environment.
-     * Any following entries are urls to routes for the environment.
+     * Any following entries are urls to routes for the environment sorted alphabetically.
      */
     public function waitFor($projectId, $environmentName, $sha)
     {
@@ -58,11 +58,13 @@ class PlatformShFacade
             $waitActivity->wait();
         }
 
+        $routeUrls = $environment->getRouteUrls();
+        // Platform.sh returns urls in a unpredictable order. Sort it alphabetically to make it predictable.
+        sort($routeUrls);
         return array_merge(
             [$environment->getPublicUrl()],
-            $environment->getRouteUrls()
+            $routeUrls
         );
-
     }
 
     /**


### PR DESCRIPTION
When placeholders use route indices these need to be predictable.
Otherwise the value of the placeholder will change from time to time.

We opt for an alphabetical order for now. At least this should leave us
in a situation where only changes to the application routes could lead
to route index changes.

Update tests accordingly.