### PR TITLE
Fix identification of post-merge environments

### DIFF
--- a/spec/PlatformShFacadeSpec.php
+++ b/spec/PlatformShFacadeSpec.php
@@ -65,12 +65,11 @@ class PlatformShFacadeSpec extends ObjectBehavior
 
     function it_finds_the_activity(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
-        $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
         $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(true);
         $environment->offsetGet('status')->willReturn('active');
-        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getActivities(10, 'environment.push')->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
         $environment->getRouteUrls()->willReturn([]);
         $project->getEnvironment('env')->willReturn($environment);
@@ -83,12 +82,11 @@ class PlatformShFacadeSpec extends ObjectBehavior
 
     function it_finds_the_activity_for_post_merge_envs(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
-        $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
         $activity->offsetGet('parameters')->willReturn(['github-pr-head' => 'sha', 'new_commit' => 'wrong sha']);
         $activity->isComplete()->willReturn(true);
         $environment->offsetGet('status')->willReturn('active');
-        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getActivities(10, 'environment.push')->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
         $environment->getRouteUrls()->willReturn([]);
         $project->getEnvironment('env')->willReturn($environment);
@@ -101,12 +99,11 @@ class PlatformShFacadeSpec extends ObjectBehavior
 
     function it_returns_route_urls(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
-        $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
         $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(true);
         $environment->offsetGet('status')->willReturn('active');
-        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getActivities(10, 'environment.push')->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
         $environment->getRouteUrls()->willReturn(['route-url-1', 'route-url-2']);
         $project->getEnvironment('env')->willReturn($environment);
@@ -119,12 +116,11 @@ class PlatformShFacadeSpec extends ObjectBehavior
 
     function it_returns_route_urls_in_alphabetical_order(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
-        $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
         $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(true);
         $environment->offsetGet('status')->willReturn('active');
-        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getActivities(10, 'environment.push')->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
         $environment->getRouteUrls()->willReturn(['www.the-url', 'api.the-url']);
         $project->getEnvironment('env')->willReturn($environment);
@@ -137,13 +133,12 @@ class PlatformShFacadeSpec extends ObjectBehavior
 
     function it_waits_on_incomplete_activity(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
-        $activity->offsetGet('type')->willReturn('environment.push');
         $activity->offsetExists('parameters')->willReturn(true);
         $activity->offsetGet('parameters')->willReturn(['new_commit' => 'sha']);
         $activity->isComplete()->willReturn(false);
         $activity->wait()->willReturn();
         $environment->offsetGet('status')->willReturn('dirty');
-        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getActivities(10, 'environment.push')->willReturn([$activity]);
         $environment->getPublicUrl()->willReturn('the-url');
         $environment->getRouteUrls()->willReturn([]);
         $project->getEnvironment('env')->willReturn($environment);

--- a/spec/PlatformShFacadeSpec.php
+++ b/spec/PlatformShFacadeSpec.php
@@ -81,6 +81,24 @@ class PlatformShFacadeSpec extends ObjectBehavior
         $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url']);
     }
 
+    function it_finds_the_activity_for_post_merge_envs(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
+    {
+        $activity->offsetGet('type')->willReturn('environment.push');
+        $activity->offsetExists('parameters')->willReturn(true);
+        $activity->offsetGet('parameters')->willReturn(['github-pr-head' => 'sha', 'new_commit' => 'wrong sha']);
+        $activity->isComplete()->willReturn(true);
+        $environment->offsetGet('status')->willReturn('active');
+        $environment->getActivities(10)->willReturn([$activity]);
+        $environment->getPublicUrl()->willReturn('the-url');
+        $environment->getRouteUrls()->willReturn([]);
+        $project->getEnvironment('env')->willReturn($environment);
+        $client->getProject('project_id')->willReturn($project);
+
+        $this->beConstructedWith($client);
+
+        $this->waitFor('project_id', 'env', 'sha')->shouldReturn(['the-url']);
+    }
+
     function it_returns_route_urls(PlatformClient $client, Project $project, Environment $environment, Activity $activity)
     {
         $activity->offsetGet('type')->willReturn('environment.push');

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -2,6 +2,7 @@
 
 namespace Dais;
 
+use Platformsh\Client\Model\Activity;
 use Platformsh\Client\PlatformClient;
 use Platformsh\Client\Model\Project;
 
@@ -43,13 +44,7 @@ class PlatformShFacade
         $waitActivity = null;
         foreach ($activities as $activity) {
             if ($activity['type'] == 'environment.push' &&
-                // Environments are built post-merge so we have to compare the PR head.
-                (isset($activity['parameters']['github-pr-head'])
-                    && $activity['parameters']['github-pr-head'] == $sha)
-                ||
-                // Environments are built as normal so we compare the new commit.
-                (isset($activity['parameters']['new_commit'])
-                    && $activity['parameters']['new_commit'] == $sha)) {
+                $this->getSha($activity) == $sha) {
                 $waitActivity = $activity;
                 break;
             }
@@ -96,6 +91,20 @@ class PlatformShFacade
         }
 
         return $environment;
+    }
+
+    /**
+     * Returns the Git SHA which an activity corresponds to.
+     */
+    protected function getSha(Activity $activity) {
+        if (isset($activity['parameters']['github-pr-head'])) {
+            // Environments are built post-merge so we have to compare the PR head.
+            return $activity['parameters']['github-pr-head'];
+        }
+        if (isset($activity['parameters']['new_commit'])) {
+            // Environments are built as normal so we compare the new commit.
+            return $activity['parameters']['new_commit'];
+        }
     }
 
     /**

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -41,13 +41,10 @@ class PlatformShFacade
         }
 
         $activities = $environment->getActivities(10, 'environment.push');
-        $waitActivity = null;
-        foreach ($activities as $activity) {
-            if ($this->getSha($activity) == $sha) {
-                $waitActivity = $activity;
-                break;
-            }
-        }
+        $waitActivites = array_filter($activities, function(Activity $activity) use ($sha) {
+            return $this->getSha($activity) == $sha;
+        });
+        $waitActivity = array_shift($waitActivites);
 
         if (!$waitActivity) {
             throw new \RuntimeException(sprintf('Activity for sha %s not found.', $sha));

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -43,8 +43,13 @@ class PlatformShFacade
         $waitActivity = null;
         foreach ($activities as $activity) {
             if ($activity['type'] == 'environment.push' &&
-                isset($activity['parameters']['new_commit']) &&
-                $activity['parameters']['new_commit'] == $sha) {
+                // Environments are built post-merge so we have to compare the PR head.
+                (isset($activity['parameters']['github-pr-head'])
+                    && $activity['parameters']['github-pr-head'] == $sha)
+                ||
+                // Environments are built as normal so we compare the new commit.
+                (isset($activity['parameters']['new_commit'])
+                    && $activity['parameters']['new_commit'] == $sha)) {
                 $waitActivity = $activity;
                 break;
             }

--- a/src/PlatformShFacade.php
+++ b/src/PlatformShFacade.php
@@ -40,11 +40,10 @@ class PlatformShFacade
             throw new \RuntimeException(sprintf('Environment %s not active.', $environmentName));
         }
 
-        $activities = $environment->getActivities(10);
+        $activities = $environment->getActivities(10, 'environment.push');
         $waitActivity = null;
         foreach ($activities as $activity) {
-            if ($activity['type'] == 'environment.push' &&
-                $this->getSha($activity) == $sha) {
+            if ($this->getSha($activity) == $sha) {
                 $waitActivity = $activity;
                 break;
             }


### PR DESCRIPTION
If the project uses a GitHub integration which is configured to build
environments posts merge the new_commit entry for the environment
represents the post-merge commit - not the head of the PR.

Consequently we have to check a different parameter for this.